### PR TITLE
Feature: support esp32 s3 c3 s2

### DIFF
--- a/ESP32SPISlave.h
+++ b/ESP32SPISlave.h
@@ -33,7 +33,7 @@ class Slave {
     friend void spi_slave_trans_done(spi_slave_transaction_t* trans);
 
     spi_slave_interface_config_t if_cfg {
-        .spics_io_num = 15,  // HSPI
+        .spics_io_num = SS,
         .flags = 0,
         .queue_size = 3,
         .mode = SPI_MODE0,
@@ -42,31 +42,31 @@ class Slave {
     };
 
     spi_bus_config_t bus_cfg {
-        .mosi_io_num = 13,  // HSPI
-        .miso_io_num = 12,  // HSPI
-        .sclk_io_num = 14,  // HSPI
+        .mosi_io_num = MOSI,
+        .miso_io_num = MISO,
+        .sclk_io_num = SCK,
         .max_transfer_sz = SOC_SPI_MAXIMUM_BUFFER_SIZE,
         .flags = SPICOMMON_BUSFLAG_SLAVE,
     };
 
-    spi_host_device_t host {HSPI_HOST};
+    spi_host_device_t host {SPI2_HOST};
 
     std::deque<spi_slave_transaction_t> transactions;
     std::deque<uint32_t> results;
 
 public:
-    // use HSPI or VSPI with default pin assignment
-    // VSPI (CS:  5, CLK: 18, MOSI: 23, MISO: 19)
-    // HSPI (CS: 15, CLK: 14, MOSI: 13, MISO: 12) -> default
+    // use SPI with the default pin assignment
     bool begin(const uint8_t spi_bus = HSPI) {
+#ifdef CONFIG_IDF_TARGET_ESP32
         bus_cfg.mosi_io_num = (spi_bus == VSPI) ? MOSI : 13;
         bus_cfg.miso_io_num = (spi_bus == VSPI) ? MISO : 12;
         bus_cfg.sclk_io_num = (spi_bus == VSPI) ? SCK : 14;
         if_cfg.spics_io_num = (spi_bus == VSPI) ? SS : 15;
+#endif
         return initialize(spi_bus);
     }
 
-    // use HSPI or VSPI with your own pin assignment
+    // use SPI with your own pin assignment
     bool begin(const uint8_t spi_bus, const int8_t sck, const int8_t miso, const int8_t mosi, const int8_t ss) {
         bus_cfg.mosi_io_num = mosi;
         bus_cfg.miso_io_num = miso;
@@ -179,8 +179,31 @@ public:
     }
 
 private:
+    spi_host_device_t hostFromBusNumber(uint8_t spi_bus) const {
+        switch (spi_bus) {
+            case FSPI:
+#ifdef CONFIG_IDF_TARGET_ESP32
+                return SPI1_HOST;
+#else
+                return SPI2_HOST;
+#endif
+            case HSPI:
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C3)
+                return SPI2_HOST;
+#else
+                return SPI3_HOST;
+#endif
+#ifdef CONFIG_IDF_TARGET_ESP32
+            case VSPI:
+                return SPI3_HOST;
+#endif
+            default:
+                return SPI2_HOST;
+        }
+    }
+
     bool initialize(const uint8_t spi_bus) {
-        host = (spi_bus == HSPI) ? HSPI_HOST : VSPI_HOST;
+        host = hostFromBusNumber(spi_bus);
         esp_err_t e = spi_slave_initialize(host, &bus_cfg, &if_cfg, SPI_DMA_DISABLED);
 
         return (e == ESP_OK);

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This is the simple SPI slave library and does NOT use DMA. Please use [ESP32DMAS
 
 ### Supported ESP32 Version
 
-| IDE         | ESP32 Board Version                  |
-| ----------- | ------------------------------------ |
-| Arduino IDE | `>= 2.0.0`                           |
-| PlatformIO  | Currently (`<= 3.4.0`) NOT Supported |
+| IDE         | ESP32 Board Version |
+| ----------- | ------------------- |
+| Arduino IDE | `>= 2.0.11`         |
+| PlatformIO  | `>= 5.0.0`          |
 
 ## Usage
 
@@ -34,8 +34,8 @@ uint8_t spi_slave_tx_buf[BUFFER_SIZE];
 uint8_t spi_slave_rx_buf[BUFFER_SIZE];
 
 void setup() {
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12 -> default
-    // VSPI = CS:  5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
     slave.begin(HSPI);
 }
@@ -67,8 +67,8 @@ uint8_t spi_slave_tx_buf[BUFFER_SIZE];
 uint8_t spi_slave_rx_buf[BUFFER_SIZE];
 
 void setup() {
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12
-    // VSPI = CS:  5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
     slave.begin(VSPI);
 }
@@ -130,8 +130,8 @@ void task_process_buffer(void* pvParameters) {
 }
 
 void setup() {
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12
-    // VSPI = CS: 5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
     slave.begin(HSPI);
 
@@ -145,14 +145,55 @@ void loop() {
 }
 ```
 
+## SPI Buses and SPI Pins
+
+This library's `bool begin(const uint8_t spi_bus = HSPI)` function uses `HSPI` as the default SPI bus as same as `SPI` library of `arduino-esp32` ([reference](https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/libraries/SPI/src/SPI.h#L61)).
+
+The pins for SPI buses are automatically attached as follows. "Default SPI Pins" means the pins defined there are the same as `MOSI`, `MISO`, `SCK`, and `SS`.
+
+| Board     | SPI       | MOSI | MISO | SCK | SS  | Default SPI Pins |
+| --------- | --------- | ---- | ---- | --- | --- | ---------------- |
+| `esp32`   | HSPI      | 13   | 12   | 14  | 15  | No               |
+| `esp32`   | VSPI/FSPI | 23   | 19   | 18  | 5   | Yes              |
+| `esp32s2` | HSPI/FSPI | 35   | 37   | 36  | 34  | Yes              |
+| `esp32s3` | HSPI/FSPI | 11   | 13   | 12  | 10  | Yes              |
+| `esp32c3` | HSPI/FSPI | 6    | 5    | 4   | 7   | Yes              |
+
+Depending on your board, the default SPI pins are defined in `pins_arduino.h`. For example, `esp32`'s default SPI pins are found [here](https://github.com/espressif/arduino-esp32/blob/e1f14331f173a00a9062f616bc9a62c358b9076f/variants/esp32/pins_arduino.h#L20-L23) (`MOSI: 23, MISO: 19, SCK: 18, SS: 5`). Please refer to [arduino-esp32/variants](https://github.com/espressif/arduino-esp32/tree/e1f14331f173a00a9062f616bc9a62c358b9076f/variants)  for your board's default SPI pins.
+
+The supported SPI buses are different from the ESP32 chip. Please note that there may be a restriction to use `FSPI` for your SPI bus. (Note: though `arduino-esp32` still uses `FSPI` and `HSPI` for all chips (v2.0.11), these are deprecated for the chips after `esp32s2`)
+
+| Chip     | FSPI              | HSPI              | VSPI               |
+| -------- | ----------------- | ----------------- | ------------------ |
+| ESP32    | SPI1_HOST(`0`) [^1] | SPI2_HOST(`1`) [^2] | SPI3_HOST (`2`) [^3] |
+| ESP32-S2 | SPI2_HOST(`1`)      | SPI3_HOST(`2`)      | -                  |
+| ESP32-S3 | SPI2_HOST(`1`)      | SPI3_HOST(`2`)      | -                  |
+| ESP32-C3 | SPI2_HOST(`1`)      | SPI2_HOST(`1`)      | -                  |
+
+[^1]: SPI bus attached to the flash (can use the same data lines but different SS)
+[^2]: SPI bus normally mapped to pins 12 - 15 on ESP32 but can be matrixed to any pins
+[^3]: SPI bus normally attached to pins 5, 18, 19, and 23 on ESP32 but can be matrixed to any pins
+
+<details>
+<summary>Reference</summary>
+
+- https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_master.html
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/cores/esp32/esp32-hal-spi.h#L28-L37
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/libraries/SPI/src/SPI.cpp#L346-L350
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/cores/esp32/esp32-hal-spi.h#L28-L37
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/cores/esp32/esp32-hal-spi.c#L719-L752
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/tools/sdk/esp32/include/driver/include/driver/sdspi_host.h#L23-L29
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/tools/sdk/esp32/include/hal/include/hal/spi_types.h#L26-L31
+- https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/tools/sdk/esp32/include/hal/include/hal/spi_types.h#L77-L87
+
+</details>
+
 ## APIs
 
 ```C++
-// use HSPI or VSPI with default pin assignment
-// VSPI (CS:  5, CLK: 18, MOSI: 23, MISO: 19)
-// HSPI (CS: 15, CLK: 14, MOSI: 13, MISO: 12) -> default
+// use SPI with the default pin assignment
 bool begin(const uint8_t spi_bus = HSPI);
-// use HSPI or VSPI with your own pin assignment
+// use SPI with your own pin assignment
 bool begin(const uint8_t spi_bus, const int8_t sck, const int8_t miso, const int8_t mosi, const int8_t ss);
 bool end();
 

--- a/examples/master_slave_polling/master_slave_polling.ino
+++ b/examples/master_slave_polling/master_slave_polling.ino
@@ -1,5 +1,9 @@
 #include <ESP32SPISlave.h>
 
+#ifndef CONFIG_IDF_TARGET_ESP32
+#error This example supports only ESP32 borads
+#endif
+
 static constexpr uint8_t VSPI_SS {SS};  // default: GPIO 5
 SPIClass master(VSPI);
 ESP32SPISlave slave;

--- a/examples/slave_echo/slave_echo.ino
+++ b/examples/slave_echo/slave_echo.ino
@@ -11,10 +11,10 @@ void setup() {
     delay(2000);
 
     // begin() after setting
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12 -> default
-    // VSPI = CS: 5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
-    slave.begin();
+    slave.begin(); // HSPI
     // slave.begin(VSPI);   // you can use VSPI like this
 
     // clear buffers

--- a/examples/slave_simple_polling/slave_simple_polling.ino
+++ b/examples/slave_simple_polling/slave_simple_polling.ino
@@ -18,10 +18,10 @@ void setup() {
     delay(2000);
 
     // begin() after setting
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12 -> default
-    // VSPI = CS:  5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
-    slave.begin();
+    slave.begin(); // HSPI
     // slave.begin(VSPI);   // you can use VSPI like this
 
     set_buffer();

--- a/examples/slave_simple_task/slave_simple_task.ino
+++ b/examples/slave_simple_task/slave_simple_task.ino
@@ -51,10 +51,10 @@ void setup() {
     delay(2000);
 
     // begin() after setting
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12 -> default
-    // VSPI = CS:  5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
-    slave.begin();
+    slave.begin(); // HSPI
     // slave.begin(VSPI);   // you can use VSPI like this
 
     set_buffer();

--- a/examples/slave_simple_wait/slave_simple_wait.ino
+++ b/examples/slave_simple_wait/slave_simple_wait.ino
@@ -11,10 +11,10 @@ void setup() {
     delay(2000);
 
     // begin() after setting
-    // HSPI = CS: 15, CLK: 14, MOSI: 13, MISO: 12 -> default
-    // VSPI = CS:  5, CLK: 18, MOSI: 23, MISO: 19
+    // note: the default pins are different depending on the board
+    // please refer to README Section "SPI Buses and SPI Pins" for more details
     slave.setDataMode(SPI_MODE0);
-    slave.begin();
+    slave.begin(); // HSPI
     // slave.begin(VSPI);   // you can use VSPI like this
 
     // clear buffers


### PR DESCRIPTION
Fixes 

- https://github.com/hideakitai/ESP32SPISlave/issues/20
- https://github.com/hideakitai/ESP32SPISlave/issues/14
- https://github.com/hideakitai/ESP32SPISlave/issues/13
- https://github.com/hideakitai/ESP32SPISlave/issues/10
- https://github.com/hideakitai/ESP32SPISlave/issues/8

Related PRs 

- https://github.com/hideakitai/ESP32SPISlave/pull/12

Contents

- Fixes compilation error for esp32
- Add support for esp32s2, s3, c3
- Update examples
- Update README