### PR TITLE
fix: remove dma related 4 bytes restriction

### DIFF
--- a/ESP32SPISlave.h
+++ b/ESP32SPISlave.h
@@ -380,10 +380,6 @@ public:
         uint8_t* rx_buf,
         size_t size
     ) {
-        if (size % 4 != 0) {
-            ESP_LOGW(TAG, "failed to queue transaction: buffer size must be multiples of 4 bytes");
-            return false;
-        }
         if (this->transactions.size() >= this->ctx.if_cfg.queue_size) {
             ESP_LOGW(TAG, "failed to queue transaction: queue is full - only %u transactions can be queued at once", this->ctx.if_cfg.queue_size);
             return false;


### PR DESCRIPTION
Fix https://github.com/hideakitai/ESP32SPISlave/issues/62